### PR TITLE
fix game over semantics but not for OpenAI gym #91

### DIFF
--- a/ctoybox/toybox/toybox/envs/atari/base.py
+++ b/ctoybox/toybox/toybox/envs/atari/base.py
@@ -20,7 +20,8 @@ class MockALE():
         return self.toybox.get_score()
 
     def game_over(self):
-        return self.toybox.game_over()
+        # Note that this is to match baselines / atari_py and not what videogames would expect.
+        return self.toybox.get_lives() == 0
 
     def saveScreenPNG(self, name):
         # Has to be bytes for ALE
@@ -114,7 +115,8 @@ class ToyboxBaseEnv(AtariEnv, ABC):
         self.score = score
     
         # Check whether the episode is done
-        done = self.toybox.game_over()
+        # use "ale" semantics here
+        done = self.ale.game_over()
     
         # Send back dignostic information
         info['lives'] = self.toybox.get_lives()

--- a/ctoybox/toybox/toybox/toybox.py
+++ b/ctoybox/toybox/toybox/toybox.py
@@ -234,7 +234,7 @@ class State(object):
         return lib.state_score(self.__state)
 
     def game_over(self):
-        return self.lives() == 0
+        return self.lives() < 0
 
     def query_json(self, query, args="null"):
         txt = rust_str(lib.state_query_json(self.__state, json_str(query).encode('utf-8'), json_str(args).encode('utf-8')))


### PR DESCRIPTION
Let's consider making toybox more sane (e.g., letting you die after lives=0, not at lives=0) ... left our gyms, e.g., base.py alone.